### PR TITLE
Fix: Remove 'Boutique Refits' from all navbars

### DIFF
--- a/in_progress_display.php@sel=bravo70.html
+++ b/in_progress_display.php@sel=bravo70.html
@@ -83,7 +83,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/in_progress_display.php@sel=buffalo_nickel.html
+++ b/in_progress_display.php@sel=buffalo_nickel.html
@@ -83,7 +83,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/in_progress_display.php@sel=dreams.html
+++ b/in_progress_display.php@sel=dreams.html
@@ -83,7 +83,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,6 @@ body {
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/other_display.php@sel=eastside_hotel.html
+++ b/other_display.php@sel=eastside_hotel.html
@@ -93,7 +93,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/other_display.php@sel=highland.html
+++ b/other_display.php@sel=highland.html
@@ -93,7 +93,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/other_display.php@sel=magnolia.html
+++ b/other_display.php@sel=magnolia.html
@@ -93,7 +93,6 @@ lighting, yacht accessories, residential interior design.">
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
+++ b/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=alexis.html
+++ b/yacht_display.php@sel=alexis.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=anaya.html
+++ b/yacht_display.php@sel=anaya.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=bigzip.html
+++ b/yacht_display.php@sel=bigzip.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=bravo72.html
+++ b/yacht_display.php@sel=bravo72.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=bravo78.html
+++ b/yacht_display.php@sel=bravo78.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=bravo88.html
+++ b/yacht_display.php@sel=bravo88.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=dreamcatcher.html
+++ b/yacht_display.php@sel=dreamcatcher.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=escapade.html
+++ b/yacht_display.php@sel=escapade.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=holland.html
+++ b/yacht_display.php@sel=holland.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=juanky.html
+++ b/yacht_display.php@sel=juanky.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=mazu.html
+++ b/yacht_display.php@sel=mazu.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
+++ b/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=rhapsody.html
+++ b/yacht_display.php@sel=rhapsody.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=samara.html
+++ b/yacht_display.php@sel=samara.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=serenity.html
+++ b/yacht_display.php@sel=serenity.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>

--- a/yacht_display.php@sel=youngone.html
+++ b/yacht_display.php@sel=youngone.html
@@ -89,7 +89,6 @@
        	<ul class="dropdown-menu">
                 <li><a href="yacht_index.php.html">COMPLETED</a></li>
                 <li><a href="in_progress_index.php.html">IN PROGRESS</a></li>
-			<li><a href="refits.php.html">BOUTIQUE REFITS</a></li>
 <!--   <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Nav header</li>
                 <li><a href="#">Separated link</a></li>


### PR DESCRIPTION
This commit ensures the 'Boutique Refits' link is removed from the navigation bar in all HTML and HTML-like files, including those with special characters in their filenames (e.g., containing '@').

A previous attempt missed some instances, which this commit addresses.