### PR TITLE
Fix: Correct image paths in in_progress_display pages

### DIFF
--- a/in_progress_display.php@sel=127.html
+++ b/in_progress_display.php@sel=127.html
@@ -131,16 +131,16 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/127/001-527-CL-127colorGAsmailler-size.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/01-CLY 127 Skylounge 01 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/02-CLY 127 Skylounge 02 -.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/03-CLY 127 Bridge 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/04-CLY 127 Bridge 03-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/05-CLY 127 Master 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/06-CLY 127 Master 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/07-CLY 127 Master Bath 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/08-CLY 127 Salon 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/127/09-CLY 127 Salon 02 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/001-527-CL-127colorGAsmailler-size.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/01-CLY 127 Skylounge 01 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/02-CLY 127 Skylounge 02 -.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/03-CLY 127 Bridge 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/04-CLY 127 Bridge 03-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/05-CLY 127 Master 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/06-CLY 127 Master 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/07-CLY 127 Master Bath 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/08-CLY 127 Salon 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/09-CLY 127 Salon 02 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/in_progress_display.php@sel=Frantoni.html
+++ b/in_progress_display.php@sel=Frantoni.html
@@ -131,39 +131,39 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/01-107 Flybridge View 4 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/02-107 Flybridge View 1 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/03-107 Flybridge View 2 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/030-107 VIP View 06-view1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/031-107 Captains View 2 Lkg Aft.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/032-107 Captains View 4 Bath Lkg Otbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/04-107 Flybridge View 3 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/05-5200 FB 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/06-107 Salon View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/07-107 Salon View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/08-107 Salon View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/09-107 Salon View 4b.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/09-5200 AD 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/10-107 Foyer View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/11-1011-07 Foyer View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/12-107 Master View 2 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/13-107 Master View 1 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/14-0107 Master View 3 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/15-107 Master View 7 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/16-107 Master Bath View 1 rev B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/17-107 Master Bath View 3 Rev A-nodrape.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/18-107 Pilothouse View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/19-107 Pilothouse View 3B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/20-107 Pilothouse View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/21-107 Galley SS Counters-AftStbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/22-107 Galley View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/23-107 Galley View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/24-107 Galley View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/25-107 Galley View 4.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/26-107 VIP View 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/27-107 VIP View 03.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/28-107 VIP View 01-Color1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Frantoni/29-107 VIP Bath-View 05.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/01-107 Flybridge View 4 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/02-107 Flybridge View 1 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/03-107 Flybridge View 2 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/030-107 VIP View 06-view1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/031-107 Captains View 2 Lkg Aft.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/032-107 Captains View 4 Bath Lkg Otbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/04-107 Flybridge View 3 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/05-5200 FB 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/06-107 Salon View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/07-107 Salon View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/08-107 Salon View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/09-107 Salon View 4b.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/09-5200 AD 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/10-107 Foyer View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/11-1011-07 Foyer View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/12-107 Master View 2 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/13-107 Master View 1 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/14-0107 Master View 3 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/15-107 Master View 7 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/16-107 Master Bath View 1 rev B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/17-107 Master Bath View 3 Rev A-nodrape.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/18-107 Pilothouse View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/19-107 Pilothouse View 3B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/20-107 Pilothouse View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/21-107 Galley SS Counters-AftStbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/22-107 Galley View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/23-107 Galley View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/24-107 Galley View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/25-107 Galley View 4.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/26-107 VIP View 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/27-107 VIP View 03.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/28-107 VIP View 01-Color1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/29-107 VIP Bath-View 05.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/in_progress_display.php@sel=Juanky_II.html
+++ b/in_progress_display.php@sel=Juanky_II.html
@@ -131,16 +131,16 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/01-Juanky SALON VIEW 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/02-D375 FOYER VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/03-D375 SKYLOUNGE VIEW 02--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/04-D375 SKYLOUNGE VIEW 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/05-Bridge View 01-ForwardView-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/06-Bridge View 02-AftView.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/06-D375 GALLEY VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/07-Galley-2-modified.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/08-D375 MASTER 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Juanky_II/09-D375 MASTER BATH VIEW 01 new stone layer.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/01-Juanky SALON VIEW 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/02-D375 FOYER VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/03-D375 SKYLOUNGE VIEW 02--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/04-D375 SKYLOUNGE VIEW 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/05-Bridge View 01-ForwardView-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/06-Bridge View 02-AftView.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/06-D375 GALLEY VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/07-Galley-2-modified.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/08-D375 MASTER 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/09-D375 MASTER BATH VIEW 01 new stone layer.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 


### PR DESCRIPTION
The image paths in the following files were pointing to the 'yachts_complete' directory instead of 'in_progress':
- in_progress_display.php@sel=127.html
- in_progress_display.php@sel=Frantoni.html
- in_progress_display.php@sel=Juanky_II.html

This commit updates the paths to correctly display the images from the 'in_progress' directory.