### PR TITLE
Added a YouTube video link to the Tintin yacht page (`yacht_display.p…

### DIFF
--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -131,6 +131,12 @@
 
 		</DIV>
 		<div class="rightColumn">
+<div style="margin-bottom: 10px;">
+    <a href="https://www.youtube.com/watch?v=1KGmiRT7yK4&ab_channel=LuxuryYachtsForSale" target="_blank" style="text-decoration: none; color: #337ab7; font-size: 16px;">
+        <span style="font-family: 'mfg_labs_iconsetregular'; font-size: 20px; margin-right: 8px; vertical-align: middle;">&#xf04f;</span>
+        tintin 34m | 112' Westport 2021
+    </a>
+</div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>


### PR DESCRIPTION
…hp@sel=Tintin.html`).

The link is placed at the top of the content area, above the first yacht image. It includes a 'play' icon (from the existing mfg_labs_iconsetregular font) to the left of the link text "tintin 34m | 112' Westport 2021". The link opens in a new tab.