### PR TITLE
I've replaced the YouTube link with an embedded player for the Tintin…

### DIFF
--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -131,12 +131,7 @@
 
 		</DIV>
 		<div class="rightColumn">
-<div style="margin-bottom: 10px;">
-    <a href="https://www.youtube.com/watch?v=1KGmiRT7yK4&ab_channel=LuxuryYachtsForSale" target="_blank" style="text-decoration: none; color: #337ab7; font-size: 16px;">
-        <span style="font-family: 'mfg_labs_iconsetregular'; font-size: 20px; margin-right: 8px; vertical-align: middle;">&#xf04f;</span>
-        tintin 34m | 112' Westport 2021
-    </a>
-</div>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/1KGmiRT7yK4?si=POEg20tKvOG0NPhL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>


### PR DESCRIPTION
… page.

The existing YouTube link on the Tintin yacht display page (yacht_display.php@sel=Tintin.html) was replaced with the standard YouTube iframe embed code to allow direct video playback on the page.