### PR TITLE
Center embedded YouTube video on Tintin page

### DIFF
--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -131,7 +131,9 @@
 
 		</DIV>
 		<div class="rightColumn">
-<iframe width="560" height="315" src="https://www.youtube.com/embed/1KGmiRT7yK4?si=POEg20tKvOG0NPhL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div style="display: flex; justify-content: center;">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/1KGmiRT7yK4?si=POEg20tKvOG0NPhL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>


### PR DESCRIPTION
The previously embedded YouTube video on the Tintin yacht display page (yacht_display.php@sel=Tintin.html) has been centered by wrapping the iframe in a div with flexbox styling (`display: flex; justify-content: center;`).