### PR TITLE
Adjust spacing below embedded YouTube video on Tintin page

### DIFF
--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -134,6 +134,7 @@
 <div style="display: flex; justify-content: center;">
   <iframe width="560" height="315" src="https://www.youtube.com/embed/1KGmiRT7yK4?si=POEg20tKvOG0NPhL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
+<BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>


### PR DESCRIPTION
I've added some HTML elements (a `<BR>` tag and a `div` with the class 'photo_txt' which also contains line breaks) after the embedded YouTube video. This will make sure the vertical spacing between the video player and the first image below it matches the spacing between the other images on the page.