### PR TITLE
Fix: Center carousel and set max-height on index page

### DIFF
--- a/index.php.html
+++ b/index.php.html
@@ -39,9 +39,13 @@ lighting, yacht accessories, residential interior design.">
 	max-height:auto;
 }
 #carousel {
-	max-width:1600px;
-	margin: 0 auto;
-	}
+	max-width: 1600px;
+	margin-left: auto;
+	margin-right: auto;
+	display: block; /* Ensure block display */
+	max-height: 729px; /* Set max height */
+	overflow: hidden; /* Hide overflow if content exceeds max-height */
+}
 	
 #body_text {
 	position: relative;


### PR DESCRIPTION
The carousel on index.php.html was reported as left-aligned. This change modifies the inline CSS for the #carousel element:
- Ensures `display: block`.
- Explicitly sets `margin-left: auto` and `margin-right: auto` for centering.
- Adds `max-height: 729px` to limit the carousel's height.
- Adds `overflow: hidden` to clip content if it exceeds the max-height.

These changes should center the carousel on the page and enforce the specified maximum height.