### PR TITLE
Fix: Center homepage carousel and text content

### DIFF
--- a/index.php.html
+++ b/index.php.html
@@ -65,6 +65,13 @@ lighting, yacht accessories, residential interior design.">
 	height:auto;
 }
 
+section {
+  max-width: 1600px;
+  margin-left: auto;
+  margin-right: auto;
+  display: block; /* Explicitly ensure block display */
+}
+
 html {
   height: 100%;
 }


### PR DESCRIPTION
The main content section on index.php.html, which includes the image carousel and the introductory text, was not centering correctly on larger screen widths. This resulted in the content appearing left-justified with excess whitespace on the right.

This commit addresses the issue by applying CSS rules to the main `<section>` element in index.php.html:
- Set `max-width: 1600px` to define a consistent maximum width for the content area.
- Set `margin-left: auto` and `margin-right: auto` to center the section horizontally within the viewport.
- Ensured `display: block` for the section.

These changes ensure that the entire main content block is centered on the page, thereby correctly centering both the carousel and the text block below it, especially on wider displays.