### PR TITLE
Feat: Apply consistent image scaling to yacht and in-progress display…

### DIFF
--- a/in_progress_display.php@sel=127.html
+++ b/in_progress_display.php@sel=127.html
@@ -17,9 +17,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Frantoni.html
+++ b/in_progress_display.php@sel=Frantoni.html
@@ -17,9 +17,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Juanky_II.html
+++ b/in_progress_display.php@sel=Juanky_II.html
@@ -17,9 +17,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=bravo70.html
+++ b/in_progress_display.php@sel=bravo70.html
@@ -28,6 +28,13 @@ lighting, yacht accessories, residential interior design.">
 	width:100%;
 	max-height:auto;
 }
+#yacht_image {
+	max-width:1600px;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
+}
 #fixed_div {
 	position: fixed;
   	top: 132px;

--- a/in_progress_display.php@sel=buffalo_nickel.html
+++ b/in_progress_display.php@sel=buffalo_nickel.html
@@ -28,6 +28,13 @@ lighting, yacht accessories, residential interior design.">
 	width:100%;
 	max-height:auto;
 }
+#yacht_image {
+	max-width:1600px;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
+}
 #fixed_div {
 	position: fixed;
   	top: 132px;

--- a/in_progress_display.php@sel=dreams.html
+++ b/in_progress_display.php@sel=dreams.html
@@ -28,6 +28,13 @@ lighting, yacht accessories, residential interior design.">
 	width:100%;
 	max-height:auto;
 }
+#yacht_image {
+	max-width:1600px;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
+}
 #fixed_div {
 	position: fixed;
   	top: 132px;

--- a/yacht_display.php@sel=BookEnds.html
+++ b/yacht_display.php@sel=BookEnds.html
@@ -17,9 +17,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=HatTrick.html
+++ b/yacht_display.php@sel=HatTrick.html
@@ -17,9 +17,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
+++ b/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=alexis.html
+++ b/yacht_display.php@sel=alexis.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=anaya.html
+++ b/yacht_display.php@sel=anaya.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bigzip.html
+++ b/yacht_display.php@sel=bigzip.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo72.html
+++ b/yacht_display.php@sel=bravo72.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo78.html
+++ b/yacht_display.php@sel=bravo78.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo88.html
+++ b/yacht_display.php@sel=bravo88.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=dreamcatcher.html
+++ b/yacht_display.php@sel=dreamcatcher.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=escapade.html
+++ b/yacht_display.php@sel=escapade.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=holland.html
+++ b/yacht_display.php@sel=holland.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=juanky.html
+++ b/yacht_display.php@sel=juanky.html
@@ -20,9 +20,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=mazu.html
+++ b/yacht_display.php@sel=mazu.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
+++ b/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=rhapsody.html
+++ b/yacht_display.php@sel=rhapsody.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=samara.html
+++ b/yacht_display.php@sel=samara.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=serenity.html
+++ b/yacht_display.php@sel=serenity.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=youngone.html
+++ b/yacht_display.php@sel=youngone.html
@@ -19,9 +19,10 @@
 <style>
 #yacht_image {
 	max-width:1600px;
-	margin: 0 20px 25px 0;
-	width:100%;
-	max-height:auto;
+	margin: 0 auto 25px auto;
+	width:auto;
+	max-height:900px;
+	display:block;
 }
 #fixed_div {
 	position: fixed;


### PR DESCRIPTION
… pages

This commit applies a consistent image styling rule to all yacht_display.php and in_progress_display.php pages.

The #yacht_image CSS ID has been updated (or created where necessary) in 26 files to ensure:
- max-height: 900px
- width: auto (to maintain aspect ratio)
- display: block
- margin: 0 auto 25px auto (for centering)

This will ensure that all images, especially vertically oriented ones, are displayed correctly, maintaining their aspect ratio and centered within the layout, capped at a maximum height of 900px.