### PR TITLE
Fix: Improve responsive scaling for images on display pages

### DIFF
--- a/in_progress_display.php@sel=127.html
+++ b/in_progress_display.php@sel=127.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Frantoni.html
+++ b/in_progress_display.php@sel=Frantoni.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Juanky_II.html
+++ b/in_progress_display.php@sel=Juanky_II.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=bravo70.html
+++ b/in_progress_display.php@sel=bravo70.html
@@ -29,11 +29,13 @@ lighting, yacht accessories, residential interior design.">
 	max-height:auto;
 }
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=buffalo_nickel.html
+++ b/in_progress_display.php@sel=buffalo_nickel.html
@@ -29,11 +29,13 @@ lighting, yacht accessories, residential interior design.">
 	max-height:auto;
 }
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=dreams.html
+++ b/in_progress_display.php@sel=dreams.html
@@ -29,11 +29,13 @@ lighting, yacht accessories, residential interior design.">
 	max-height:auto;
 }
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=BookEnds.html
+++ b/yacht_display.php@sel=BookEnds.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=HatTrick.html
+++ b/yacht_display.php@sel=HatTrick.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -16,11 +16,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
+++ b/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=alexis.html
+++ b/yacht_display.php@sel=alexis.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=anaya.html
+++ b/yacht_display.php@sel=anaya.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bigzip.html
+++ b/yacht_display.php@sel=bigzip.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo72.html
+++ b/yacht_display.php@sel=bravo72.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo78.html
+++ b/yacht_display.php@sel=bravo78.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo88.html
+++ b/yacht_display.php@sel=bravo88.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=dreamcatcher.html
+++ b/yacht_display.php@sel=dreamcatcher.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=escapade.html
+++ b/yacht_display.php@sel=escapade.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=holland.html
+++ b/yacht_display.php@sel=holland.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=juanky.html
+++ b/yacht_display.php@sel=juanky.html
@@ -19,11 +19,13 @@
 <link rel="stylesheet" type="text/css" href="css/overlay.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=mazu.html
+++ b/yacht_display.php@sel=mazu.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
+++ b/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=rhapsody.html
+++ b/yacht_display.php@sel=rhapsody.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=samara.html
+++ b/yacht_display.php@sel=samara.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=serenity.html
+++ b/yacht_display.php@sel=serenity.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=youngone.html
+++ b/yacht_display.php@sel=youngone.html
@@ -18,11 +18,13 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	max-width:1600px;
+	display: block;
 	margin: 0 auto 25px auto;
-	width:auto;
-	max-height:900px;
-	display:block;
+	max-width: 100%; /* Add this for responsive scaling */
+	max-width: 1600px; /* Ensure this original overall max width is present */
+	max-height: 900px;
+	width: auto;
+	height: auto;
 }
 #fixed_div {
 	position: fixed;


### PR DESCRIPTION
This commit refines the CSS for the #yacht_image rule in all yacht_display.php@sel=*.html and in_progress_display.php@sel=*.html pages (26 files) to ensure proper responsive scaling.

The following CSS properties were ensured for #yacht_image:
- display: block;
- margin: 0 auto 25px auto; (for centering)
- max-width: 100%; (key for responsive scaling with container)
- max-width: 1600px; (overall cap for large screens)
- max-height: 900px; (for vertical image height control)
- width: auto; (maintains aspect ratio)
- height: auto; (maintains aspect ratio)

This combination allows images to scale down with the browser window while respecting aspect ratio, maximum height for vertical images, and an overall maximum width.