### PR TITLE
Fix: Improve image responsiveness and aspect ratio handling

### DIFF
--- a/css/responsee.css
+++ b/css/responsee.css
@@ -37,7 +37,7 @@ a, a:link, a:visited, a:hover, a:active {
 img {
   border:0;
 	height:auto;
-	width:100%;
+	max-width:100%; /* Changed from width:100% */
 	}
 table {
 	background:none repeat scroll 0 0 #fff;

--- a/in_progress_display.php@sel=127.html
+++ b/in_progress_display.php@sel=127.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Frantoni.html
+++ b/in_progress_display.php@sel=Frantoni.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=Juanky_II.html
+++ b/in_progress_display.php@sel=Juanky_II.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=bravo70.html
+++ b/in_progress_display.php@sel=bravo70.html
@@ -30,12 +30,14 @@ lighting, yacht accessories, residential interior design.">
 }
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=buffalo_nickel.html
+++ b/in_progress_display.php@sel=buffalo_nickel.html
@@ -30,12 +30,14 @@ lighting, yacht accessories, residential interior design.">
 }
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/in_progress_display.php@sel=dreams.html
+++ b/in_progress_display.php@sel=dreams.html
@@ -30,12 +30,14 @@ lighting, yacht accessories, residential interior design.">
 }
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=BookEnds.html
+++ b/yacht_display.php@sel=BookEnds.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=HatTrick.html
+++ b/yacht_display.php@sel=HatTrick.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -17,12 +17,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
+++ b/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=alexis.html
+++ b/yacht_display.php@sel=alexis.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=anaya.html
+++ b/yacht_display.php@sel=anaya.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bigzip.html
+++ b/yacht_display.php@sel=bigzip.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo72.html
+++ b/yacht_display.php@sel=bravo72.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo78.html
+++ b/yacht_display.php@sel=bravo78.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=bravo88.html
+++ b/yacht_display.php@sel=bravo88.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=dreamcatcher.html
+++ b/yacht_display.php@sel=dreamcatcher.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=escapade.html
+++ b/yacht_display.php@sel=escapade.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=holland.html
+++ b/yacht_display.php@sel=holland.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=juanky.html
+++ b/yacht_display.php@sel=juanky.html
@@ -20,12 +20,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=mazu.html
+++ b/yacht_display.php@sel=mazu.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
+++ b/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=rhapsody.html
+++ b/yacht_display.php@sel=rhapsody.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=samara.html
+++ b/yacht_display.php@sel=samara.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=serenity.html
+++ b/yacht_display.php@sel=serenity.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;

--- a/yacht_display.php@sel=youngone.html
+++ b/yacht_display.php@sel=youngone.html
@@ -19,12 +19,14 @@
 <style>
 #yacht_image {
 	display: block;
-	margin: 0 auto 25px auto;
-	max-width: 100%; /* Add this for responsive scaling */
-	max-width: 1600px; /* Ensure this original overall max width is present */
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 25px;
+	max-width: 1600px;
 	max-height: 900px;
 	width: auto;
 	height: auto;
+	object-fit: contain;
 }
 #fixed_div {
 	position: fixed;


### PR DESCRIPTION
This commit addresses issues with image display on yacht pages:

- Modified inline CSS for #yacht_image in yacht_display.php and in_progress_display.php files:
    - Ensured `display: block` and used `margin-left: auto`, `margin-right: auto` for reliable centering.
    - Maintained `max-width: 1600px` and `max-height: 900px`.
    - Set `width: auto` and `height: auto` to preserve aspect ratio.
    - Added `object-fit: contain` to ensure images scale within bounds without distortion.
    - Removed a redundant `max-width: 100%` rule.

- Updated generic `img` CSS in `css/responsee.css`:
    - Changed `width: 100%` to `max-width: 100%`. This allows images to scale down responsively but prevents them from stretching beyond their natural size or to fill containers if they are smaller, thus better preserving aspect ratio.

These changes ensure that:
- Vertically oriented images are capped at 900px height.
- All images maintain their correct aspect ratio.
- Vertical images are centered correctly.
- Horizontal images utilize available width up to 1600px.
- Images are responsive to browser window resizing.