### PR TITLE
Fix: Correct image responsiveness, scaling, and centering

### DIFF
--- a/in_progress_display.php@sel=127.html
+++ b/in_progress_display.php@sel=127.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -128,16 +128,16 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/in_progress/127/001-527-CL-127colorGAsmailler-size.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/01-CLY 127 Skylounge 01 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/02-CLY 127 Skylounge 02 -.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/03-CLY 127 Bridge 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/04-CLY 127 Bridge 03-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/05-CLY 127 Master 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/06-CLY 127 Master 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/07-CLY 127 Master Bath 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/08-CLY 127 Salon 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/127/09-CLY 127 Salon 02 .jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/001-527-CL-127colorGAsmailler-size.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/01-CLY 127 Skylounge 01 .jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/02-CLY 127 Skylounge 02 -.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/03-CLY 127 Bridge 02.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/04-CLY 127 Bridge 03-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/05-CLY 127 Master 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/06-CLY 127 Master 02.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/07-CLY 127 Master Bath 01-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/08-CLY 127 Salon 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/127/09-CLY 127 Salon 02 .jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/in_progress_display.php@sel=Frantoni.html
+++ b/in_progress_display.php@sel=Frantoni.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -128,39 +128,39 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/in_progress/Frantoni/01-107 Flybridge View 4 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/02-107 Flybridge View 1 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/03-107 Flybridge View 2 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/030-107 VIP View 06-view1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/031-107 Captains View 2 Lkg Aft.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/032-107 Captains View 4 Bath Lkg Otbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/04-107 Flybridge View 3 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/05-5200 FB 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/06-107 Salon View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/07-107 Salon View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/08-107 Salon View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/09-107 Salon View 4b.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/09-5200 AD 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/10-107 Foyer View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/11-1011-07 Foyer View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/12-107 Master View 2 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/13-107 Master View 1 Rev A copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/14-0107 Master View 3 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/15-107 Master View 7 Rev A.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/16-107 Master Bath View 1 rev B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/17-107 Master Bath View 3 Rev A-nodrape.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/18-107 Pilothouse View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/19-107 Pilothouse View 3B.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/20-107 Pilothouse View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/21-107 Galley SS Counters-AftStbd.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/22-107 Galley View 2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/23-107 Galley View 1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/24-107 Galley View 3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/25-107 Galley View 4.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/26-107 VIP View 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/27-107 VIP View 03.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/28-107 VIP View 01-Color1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Frantoni/29-107 VIP Bath-View 05.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/01-107 Flybridge View 4 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/02-107 Flybridge View 1 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/03-107 Flybridge View 2 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/030-107 VIP View 06-view1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/031-107 Captains View 2 Lkg Aft.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/032-107 Captains View 4 Bath Lkg Otbd.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/04-107 Flybridge View 3 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/05-5200 FB 02.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/06-107 Salon View 1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/07-107 Salon View 2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/08-107 Salon View 3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/09-107 Salon View 4b.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/09-5200 AD 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/10-107 Foyer View 1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/11-1011-07 Foyer View 2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/12-107 Master View 2 Rev A copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/13-107 Master View 1 Rev A copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/14-0107 Master View 3 Rev A.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/15-107 Master View 7 Rev A.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/16-107 Master Bath View 1 rev B.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/17-107 Master Bath View 3 Rev A-nodrape.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/18-107 Pilothouse View 1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/19-107 Pilothouse View 3B.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/20-107 Pilothouse View 2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/21-107 Galley SS Counters-AftStbd.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/22-107 Galley View 2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/23-107 Galley View 1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/24-107 Galley View 3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/25-107 Galley View 4.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/26-107 VIP View 02.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/27-107 VIP View 03.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/28-107 VIP View 01-Color1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Frantoni/29-107 VIP Bath-View 05.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/in_progress_display.php@sel=Juanky_II.html
+++ b/in_progress_display.php@sel=Juanky_II.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -128,16 +128,16 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/in_progress/Juanky_II/01-Juanky SALON VIEW 01-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/02-D375 FOYER VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/03-D375 SKYLOUNGE VIEW 02--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/04-D375 SKYLOUNGE VIEW 02.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/05-Bridge View 01-ForwardView-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/06-Bridge View 02-AftView.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/06-D375 GALLEY VIEW 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/07-Galley-2-modified.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/08-D375 MASTER 01.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/in_progress/Juanky_II/09-D375 MASTER BATH VIEW 01 new stone layer.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/01-Juanky SALON VIEW 01-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/02-D375 FOYER VIEW 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/03-D375 SKYLOUNGE VIEW 02--.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/04-D375 SKYLOUNGE VIEW 02.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/05-Bridge View 01-ForwardView-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/06-Bridge View 02-AftView.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/06-D375 GALLEY VIEW 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/07-Galley-2-modified.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/08-D375 MASTER 01.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/in_progress/Juanky_II/09-D375 MASTER BATH VIEW 01 new stone layer.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=BookEnds.html
+++ b/yacht_display.php@sel=BookEnds.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -128,34 +128,34 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/001-lrg res--26.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/002-S5 1--3-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/003-S-3 1--2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/004-S8- 1--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-StbdWW2 1--26.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-lrg res--28.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-lrg res-6558.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/006-lrg res--30.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/007-lrg res--91.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/008-lrg res--90.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/009-lrg res--92.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/010-lrg res--67.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/011-lrg res--31.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/012-lrg res--32.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/013 Batch1-BarPW.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/014-lrg res-7283.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/015-lrg res--61.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/016-MB-3 1--23.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/017-lrg res--83.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/018-MH-2-1-28.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/019-lrg res--43 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/019-lrg res--46 copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/020-lrg res--59.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/021-SS1-1--20.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/022-AD1 1--6-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/023-AD3-1--8-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/024-FB1--30--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/BookEnds/025-Mast1 1--37-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/001-lrg res--26.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/002-S5 1--3-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/003-S-3 1--2-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/004-S8- 1--.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-StbdWW2 1--26.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-lrg res--28.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/005-lrg res-6558.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/006-lrg res--30.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/007-lrg res--91.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/008-lrg res--90.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/009-lrg res--92.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/010-lrg res--67.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/011-lrg res--31.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/012-lrg res--32.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/013 Batch1-BarPW.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/014-lrg res-7283.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/015-lrg res--61.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/016-MB-3 1--23.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/017-lrg res--83.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/018-MH-2-1-28.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/019-lrg res--43 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/019-lrg res--46 copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/020-lrg res--59.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/021-SS1-1--20.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/022-AD1 1--6-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/023-AD3-1--8-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/024-FB1--30--.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/BookEnds/025-Mast1 1--37-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=HatTrick.html
+++ b/yacht_display.php@sel=HatTrick.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -128,31 +128,31 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/01-15-Hat Trick_salon_3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/02-11-Hat Trick_dining_1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/03-13-Hat Trick_salon_9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/04-8-1-1Hat Trick_stairs_to_pilothouse_1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/05-4-Hat Trick_pilothouse_5.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/06-5-Hat Trick_pilothouse_9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/07-6-Hat Trick_pilothouse_7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/08-10-Hat Trick_galley_4-2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/09-8-Hat Trick_galley_1-2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/10-9-Hat Trick_galley_10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/11-24-Hat Trick011-_lower_foyer_3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/12-23-Hat Trick_lower_foyer_2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/13-28-Hat Trick_master_stateroom_3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/14-25-Hat Trick_master_head_8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/15-25-1-Hat Trick_forward_stateroom_1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/16-30-Hat Trick_port_guest_stateroom_2--.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/17-32-Hat Trick_starboard_guest_stateroom_3.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/18-Hat Trick_day_head_1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/19-18-Hat Trick_aft_deck_2.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/20-19-Hat Trick_aft_deck_9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/21-20-Hat Trick_aft_deck_5.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/22-IMG_0634.JPG' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/23-2-1Hat Trick_bow_7 - Copy.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/24-3-Hat Trick_flybridge_12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Hat Trick/25-2-Hat Trick_flybridge_3-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/01-15-Hat Trick_salon_3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/02-11-Hat Trick_dining_1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/03-13-Hat Trick_salon_9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/04-8-1-1Hat Trick_stairs_to_pilothouse_1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/05-4-Hat Trick_pilothouse_5.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/06-5-Hat Trick_pilothouse_9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/07-6-Hat Trick_pilothouse_7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/08-10-Hat Trick_galley_4-2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/09-8-Hat Trick_galley_1-2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/10-9-Hat Trick_galley_10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/11-24-Hat Trick011-_lower_foyer_3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/12-23-Hat Trick_lower_foyer_2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/13-28-Hat Trick_master_stateroom_3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/14-25-Hat Trick_master_head_8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/15-25-1-Hat Trick_forward_stateroom_1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/16-30-Hat Trick_port_guest_stateroom_2--.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/17-32-Hat Trick_starboard_guest_stateroom_3.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/18-Hat Trick_day_head_1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/19-18-Hat Trick_aft_deck_2.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/20-19-Hat Trick_aft_deck_9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/21-20-Hat Trick_aft_deck_5.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/22-IMG_0634.JPG' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/23-2-1Hat Trick_bow_7 - Copy.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/24-3-Hat Trick_flybridge_12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Hat Trick/25-2-Hat Trick_flybridge_3-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=Tintin.html
+++ b/yacht_display.php@sel=Tintin.html
@@ -16,15 +16,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -132,26 +132,26 @@
   <iframe width="560" height="315" src="https://www.youtube.com/embed/1KGmiRT7yK4?si=POEg20tKvOG0NPhL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 <BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/013--20211027_192939000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/014--20211027_193041000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/015--LD-MB1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/016--20211027_203150000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/017--20211027_192504000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/018-T-gym2025-06-01_12-50-45.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/019--20211027_192640000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/02--MD-Salon1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/020-T-AD2025-06-01_12-51-14.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/021-T-BD-2025-06-01_12-52-18.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/03-T-SalonFD.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/04-T-SAlon2025-06-01_12-58-24.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/05-T-ph-2025-06-01_12-53-54.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/07--20211027_203507000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/08--20211027_203317000_iOS.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/09--DH-1.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
-			<img id='yacht_image' src='img/yachts_complete/Tintin/Exterior-2025-06-01_14-08-47.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/0011-20211027_194513000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/010--MD_PortWw2-.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/012--MF_1---.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/013--20211027_192939000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/014--20211027_193041000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/015--LD-MB1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/016--20211027_203150000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/017--20211027_192504000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/018-T-gym2025-06-01_12-50-45.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/019--20211027_192640000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/02--MD-Salon1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/020-T-AD2025-06-01_12-51-14.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/021-T-BD-2025-06-01_12-52-18.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/03-T-SalonFD.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/04-T-SAlon2025-06-01_12-58-24.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/05-T-ph-2025-06-01_12-53-54.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/07--20211027_203507000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/08--20211027_203317000_iOS.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/09--DH-1.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/Tintin/Exterior-2025-06-01_14-08-47.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
+++ b/yacht_display.php@sel=afterglow&tour=my.matterport.com%2Fmodels%2FFa9WwRP6q17.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/afterglow/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/afterglow/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/13.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/afterglow/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/afterglow/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/afterglow/13.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=alexis.html
+++ b/yacht_display.php@sel=alexis.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/alexis/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/alexis/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/alexis/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/alexis/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/alexis/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/alexis/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/alexis/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/alexis/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=anaya.html
+++ b/yacht_display.php@sel=anaya.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/anaya/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/anaya/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/anaya/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/anaya/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/anaya/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=bigzip.html
+++ b/yacht_display.php@sel=bigzip.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/bigzip/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bigzip/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/bigzip/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bigzip/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=bravo72.html
+++ b/yacht_display.php@sel=bravo72.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/bravo72/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo72/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/13.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/bravo72/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo72/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo72/13.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=bravo78.html
+++ b/yacht_display.php@sel=bravo78.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/bravo78/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo78/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo78/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/bravo78/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo78/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo78/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=bravo88.html
+++ b/yacht_display.php@sel=bravo88.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/bravo88/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/bravo88/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/13.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/bravo88/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/bravo88/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/bravo88/13.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=dreamcatcher.html
+++ b/yacht_display.php@sel=dreamcatcher.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/dreamcatcher/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/dreamcatcher/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/dreamcatcher/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=escapade.html
+++ b/yacht_display.php@sel=escapade.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/escapade/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/escapade/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/escapade/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/escapade/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/escapade/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/escapade/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/escapade/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/escapade/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=holland.html
+++ b/yacht_display.php@sel=holland.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/holland/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/holland/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/13.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/holland/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/holland/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/holland/13.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=juanky.html
+++ b/yacht_display.php@sel=juanky.html
@@ -19,15 +19,15 @@
 <link rel="stylesheet" type="text/css" href="css/overlay.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -132,13 +132,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/juanky/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/juanky/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/juanky/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/juanky/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/juanky/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=mazu.html
+++ b/yacht_display.php@sel=mazu.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/mazu/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/mazu/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/mazu/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/mazu/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/mazu/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
+++ b/yacht_display.php@sel=premier&tour=my.matterport.com%2Fmodels%2FxGw4Epropox.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/premier/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/premier/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/11.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/12.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/13.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/premier/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/premier/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/11.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/12.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/premier/13.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=rhapsody.html
+++ b/yacht_display.php@sel=rhapsody.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/rhapsody/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/rhapsody/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/rhapsody/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=samara.html
+++ b/yacht_display.php@sel=samara.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/samara/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/samara/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/samara/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/samara/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/samara/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/samara/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/samara/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/samara/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=serenity.html
+++ b/yacht_display.php@sel=serenity.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/serenity/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/serenity/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/serenity/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/serenity/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/serenity/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 

--- a/yacht_display.php@sel=youngone.html
+++ b/yacht_display.php@sel=youngone.html
@@ -18,15 +18,15 @@
 <LINK REL=STYLESHEET TYPE="text/css" HREF="two_col.css">
 <style>
 #yacht_image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 25px;
-	max-width: 1600px;
-	max-height: 900px;
-	width: auto;
-	height: auto;
-	object-fit: contain;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 25px;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: 900px;
+    object-fit: contain;
 }
 #fixed_div {
 	position: fixed;
@@ -130,13 +130,13 @@
 
 		</DIV>
 		<div class="rightColumn">
-			<img id='yacht_image' src='img/yachts_complete/youngone/1.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/2.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/3.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/4.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/5.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/6.jpg' width='1600px' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>			
-			<img id='yacht_image' src='img/yachts_complete/youngone/7.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/8.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/9.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/10.jpg' width='1600px' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>	
+			<img id='yacht_image' src='img/yachts_complete/youngone/1.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/2.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/3.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/4.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/5.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/6.jpg' /><BR>			<div class='photo_txt'>&nbsp;<BR><BR></div>
+			<img id='yacht_image' src='img/yachts_complete/youngone/7.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/8.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/9.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div><img id='yacht_image' src='img/yachts_complete/youngone/10.jpg' /><BR><div class='photo_txt'>&nbsp;<BR><BR></div>
 		</div>
 	</div>
 


### PR DESCRIPTION
This commit addresses issues where yacht images were not resizing with the browser window and were not centering correctly. The previous attempt's CSS was refined.

Key changes:
1. Removed inline `width='1600px'` attributes from all `<img>` tags with `id='yacht_image'` across applicable `yacht_display.php` and `in_progress_display.php` files. This was the primary cause of images not scaling down.

2. Updated the inline CSS for `#yacht_image` in these files to: ```css #yacht_image { display: block; margin-left: auto; margin-right: auto; margin-bottom: 25px; max-width: 100%; /* Ensures responsiveness within the container */
       width: auto;     /* Maintains aspect ratio */
       height: auto;    /* Maintains aspect ratio */
       max-height: 900px; /* Constrains height for vertical images */
       object-fit: contain; /* Ensures image fits bounds, maintains aspect ratio */
   }
   ```
   The critical change here is `max-width: 100%` which allows the image to scale with its parent container, fixing the resizing problem.

3. Confirmed that the generic `img` style in `css/responsee.css` remains `max-width: 100%;`, which is beneficial for overall site image handling.

These changes ensure that:
- Images now correctly resize with the browser window.
- Images are properly centered on the page.
- Vertically oriented images are capped at 900px height while maintaining aspect ratio.
- All images maintain their original aspect ratio without distortion.
- Horizontal images use the available width of their container.