### PR TITLE
Fix: Remove text from homepage carousel images

### DIFF
--- a/index.php.html
+++ b/index.php.html
@@ -190,268 +190,68 @@ body {
             <div id="owl-demo" class="owl-carousel owl-theme">
                <div class="item">
                   <img src="img/carousel/01.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Interior Design for Yachts</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/02.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>From Concept to Launch</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/03.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Carefully Selected Surfaces and Materials</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
 
  				<div class="item">
                   <img src="img/carousel/04.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Unique Environments for Your Life at Sea</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
  				<div class="item">
                   <img src="img/carousel/05.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Art & Accessories to Match the Boat Theme</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
 
 				<div class="item">
                   <img src="img/carousel/06.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Beautiful Details Accent the Theme</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
  				<div class="item">
                   <img src="img/carousel/07.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Safety and Comfort is Always Stressed</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
 
 				<div class="item">
                   <img src="img/carousel/08.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Commissioned Art May be Included</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
 
 				<div class="item">
                   <img src="img/carousel/09.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Styling, Lighting, Furnishings</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
 
 				<div class="item">
                   <img src="img/carousel/10.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>Interior Design for Yachts</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/11.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 11 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/12.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 12 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/13.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 13 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/14.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 14 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/15.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 15 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/16.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 16 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/17.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 17 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/18.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 18 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/19.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 19 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
                <div class="item">
                   <img src="img/carousel/20.jpg" alt="">
-                  <div class="carousel-text">
-                     <div class="line">
-                        <div class="s-12 l-9">
-                           <h2>New Image 20 Title</h2>
-                        </div>
-                        <div class="s-12 l-9">
-                           <!--<p>&nbsp; &nbsp; &nbsp; &nbsp; descriptive text </p>-->
-                        </div>
-                     </div>
-                  </div>
                </div>
             </div>
          </div>


### PR DESCRIPTION
The text content, including titles and descriptive paragraphs, displayed below each image in the homepage carousel has been removed.

This change modifies `index.php.html` by deleting the `div` elements with the class `carousel-text` within each carousel item. The images themselves and the carousel functionality are preserved.