### PR TITLE
Fix: Correct carousel display issue on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,12 @@ lighting, yacht accessories, residential interior design.">
 	max-height:auto;
 }
 #carousel {
-	max-width:1600px;
+	max-width: 1600px;
+	margin-left: auto;
+	margin-right: auto;
+	display: block; /* Ensure block display */
+	max-height: 729px; /* Set max height */
+	overflow: hidden; /* Hide overflow if content exceeds max-height */
 	}
 	
 #body_text {


### PR DESCRIPTION
The initial loading of index.html caused the page to appear scrolled down, with only the text below the image carousel visible. This was due to missing CSS properties for the carousel container (`#carousel`).

This commit applies the following CSS properties from `index.php.html` (which loaded correctly) to `index.html`'s `#carousel` style:
- `max-height: 729px;`
- `overflow: hidden;`
- `margin-left: auto;`
- `margin-right: auto;`
- `display: block;`

These changes constrain the carousel's height and prevent it from overflowing and pushing subsequent content down, resolving the initial display problem.

The file `index.html` is confirmed to be the default document loaded for the root domain.